### PR TITLE
Update django dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.0.13
+Django>=2.2.9,<3
 django-bootstrap4
 django-cleanup
 django-auth-ldap


### PR DESCRIPTION
The django version previously specified in the requirements was subject to
CVE-2019-19844. This changes the version to >=2.29, and removes the pinning to
a specific version, in order to avoid conflicts with other dependencies or
applications.