### PR TITLE
Api token

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django>=2.2.10,<3
 django-bootstrap4
 django-cleanup
 django-auth-ldap
-pymysql
+mysqlclient>=1.13
 python-memcached
 gunicorn
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django>=2.2.10,<3
 django-bootstrap4
 django-cleanup
 django-auth-ldap
-mysqlclient>=1.13
+mysqlclient>=1.3.13
 python-memcached
 gunicorn
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pymysql
 python-memcached
 gunicorn
 whitenoise
+djangorestframework

--- a/sendfilestome/settings.py.example
+++ b/sendfilestome/settings.py.example
@@ -38,6 +38,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_cleanup',
+    'rest_framework',
+    'rest_framework.authtoken',
     'bootstrap4',
     'sendfilestome',
 ]
@@ -126,8 +128,8 @@ STATIC_URL = '/static/'
 
 # SendFilesToMe settings
 MEDIA_ROOT = os.path.join(BASE_DIR, 'uploads')
-SFTM_UPLOAD_AUTH_ENABLED = False
-SFTM_DOWNLOAD_AUTH_ENABLED = False
+SFTM_UPLOAD_AUTH_ENABLED = True
+SFTM_DOWNLOAD_AUTH_ENABLED = True
 SFTM_LIST_ALL_WHEN_AUTHENTICATED = True
 
 # try to import local settings that will override the default ones

--- a/sendfilestome/urls.py
+++ b/sendfilestome/urls.py
@@ -17,6 +17,8 @@ from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 
+from rest_framework.authtoken import views as rest_views
+
 from sendfilestome import views
 
 urlpatterns = [
@@ -30,4 +32,6 @@ urlpatterns = [
         views.SFTMFile.as_view(), name='file'),
     url('c/(?P<container_name>[^/]+)$', views.Container.as_view(),
         name='container'),
+    url(r'^api/container/(?P<container_name>[^/]+)$', views.ContainerAPI.as_view()),
+    url(r'^api/token', rest_views.obtain_auth_token)
 ]


### PR DESCRIPTION
Add a token system in order to push files in containers and avoid CSRF verification
User can :
 - Get token : **POST** on /api/token, body_params: [username, password]
 - Upload file :  **POST**  on /api/container/<container_name>, body_params: [file, name], header: {Authorization: "Token <user_token>"}
 If user upload in an unknown container, the container will be created.